### PR TITLE
Add URL encoding of database names

### DIFF
--- a/src/couchdb.erl
+++ b/src/couchdb.erl
@@ -101,7 +101,8 @@ database_record(#server{options=ServerOptions}=Server, <<DatabaseName/binary>>, 
         andalso database_name_is_valid(DatabaseName) of
             true -> 
                 Options = ServerOptions ++ DatabaseOptions,
-                {ok, #db{server=Server, name=DatabaseName, options=Options}};
+                DatabaseNameURLEnc = uri_string:quote(DatabaseName), %URL Encode the DB name binary
+                {ok, #db{server=Server, name=DatabaseNameURLEnc, options=Options}};
             false -> {error, "Options must be a valid tuplelist"} 
     end.
 


### PR DESCRIPTION
Add URL encoding of database names, so that the special characters which CouchDB server allows for in database names can be used, such as `databasexyz/test1` or `database_xyz+account1` or similar.